### PR TITLE
处理多个屏幕的 DPI 缩放。

### DIFF
--- a/Source/Graphics/Graphics.Core/Graphics.Core.csproj
+++ b/Source/Graphics/Graphics.Core/Graphics.Core.csproj
@@ -13,8 +13,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Hexa.NET.ImGui" Version="1.0.4" />
-		<PackageReference Include="Hexa.NET.ImGuizmo" Version="1.0.4" />
+		<PackageReference Include="Hexa.NET.ImGui" Version="1.1.0" />
+		<PackageReference Include="Hexa.NET.ImGuizmo" Version="1.1.0" />
 		<PackageReference Include="Silk.NET.Input" Version="2.21.0" />
 		<PackageReference Include="Silk.NET.Maths" Version="2.21.0" />
 		<PackageReference Include="Silk.NET.Shaderc" Version="2.21.0" />

--- a/Source/Graphics/Graphics.Core/Window/Window.Status.cs
+++ b/Source/Graphics/Graphics.Core/Window/Window.Status.cs
@@ -39,6 +39,19 @@ unsafe partial class Window
         get => new(_window.FramebufferSize.X, _window.FramebufferSize.Y);
     }
 
+    public float DpiScale
+    {
+        get
+        {
+            int displayIndex = _sdl.GetWindowDisplayIndex((SDLWindow*)_window.Handle);
+
+            float ddpi;
+            _sdl.GetDisplayDPI(displayIndex, &ddpi, null, null);
+
+            return ddpi / 96.0f;
+        }
+    }
+
     public Vector2 MinimumSize
     {
         get

--- a/Source/Graphics/Graphics.Core/Window/Window.cs
+++ b/Source/Graphics/Graphics.Core/Window/Window.cs
@@ -77,6 +77,11 @@ public unsafe partial class Window : DisposableObject
         return new Window(window, window.CreateInput());
     }
 
+    public static bool IsMouseFocusOnWindow()
+    {
+        return _sdl.GetMouseFocus() != null;
+    }
+
     public static MouseButton[] GetGlobalMouseState(out Vector2 position)
     {
         int x, y;
@@ -109,6 +114,13 @@ public unsafe partial class Window : DisposableObject
     public static void FreeCursor(Cursor* cursor)
     {
         _sdl.FreeCursor(cursor);
+    }
+
+    public static void SetTextIputRect(int x, int y, int w, int h)
+    {
+        Rectangle<int> rect = new(x, y, w, h);
+
+        _sdl.SetTextInputRect(&rect);
     }
 
     public static int GetDisplayCount()

--- a/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiController.cs
+++ b/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiController.cs
@@ -258,6 +258,8 @@ public unsafe class ImGuiController : DisposableObject
         }
 
         InitializePlatform();
+
+        io.PlatformSetImeDataFn = (void*)Marshal.GetFunctionPointerForDelegate(_setImeData);
     }
 
     private void InitializePlatform()
@@ -340,10 +342,6 @@ public unsafe class ImGuiController : DisposableObject
         platformIO.PlatformSetWindowAlpha = (void*)Marshal.GetFunctionPointerForDelegate(_setWindowAlpha);
         platformIO.PlatformUpdateWindow = (void*)Marshal.GetFunctionPointerForDelegate(_updateWindow);
         platformIO.PlatformOnChangedViewport = (void*)Marshal.GetFunctionPointerForDelegate(_onChangedViewport);
-
-        ImGuiIOPtr imGuiIO = ImGui.GetIO();
-
-        imGuiIO.PlatformSetImeDataFn = (void*)Marshal.GetFunctionPointerForDelegate(_setImeData);
     }
 
     private void CreateWindow(ImGuiViewport* vp)

--- a/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiController.cs
+++ b/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiController.cs
@@ -34,6 +34,8 @@ public unsafe class ImGuiController : DisposableObject
 
     private ImGuiRenderer _imGuiRenderer = null!;
 
+    private float _currentDpiScale = 1.0f;
+
     #region Constructors
     public ImGuiController(Window window,
                            GraphicsDevice graphicsDevice,
@@ -89,6 +91,7 @@ public unsafe class ImGuiController : DisposableObject
     {
         SetPerFrameImGuiData(deltaSeconds);
 
+        UpdateDpiScale();
         UpdateMouseState();
         UpdateMouseCursor();
 
@@ -168,6 +171,21 @@ public unsafe class ImGuiController : DisposableObject
         io.DeltaTime = deltaSeconds;
     }
 
+    private void UpdateDpiScale()
+    {
+        float dpiScale = _window.DpiScale;
+
+        if (_currentDpiScale != dpiScale)
+        {
+            ImGuiStylePtr style = ImGui.GetStyle();
+
+            style.ScaleAllSizes(1.0f / _currentDpiScale);
+            style.ScaleAllSizes(dpiScale);
+
+            _currentDpiScale = dpiScale;
+        }
+    }
+
     private static void UpdateMouseState()
     {
         ImGuiIOPtr io = ImGui.GetIO();
@@ -203,7 +221,6 @@ public unsafe class ImGuiController : DisposableObject
         ImGuizmo.SetImGuiContext(_imGuiContext);
 
         ImGui.StyleColorsDark();
-        ImGui.GetStyle().ScaleAllSizes(_window.DpiScale);
 
         ImGuiIOPtr io = ImGui.GetIO();
 

--- a/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiController.cs
+++ b/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiController.cs
@@ -162,12 +162,8 @@ public unsafe class ImGuiController : DisposableObject
     {
         ImGuiIOPtr io = ImGui.GetIO();
 
-        io.DisplaySize = _window.Size;
-
-        if (_window.Size.X > 0 && _window.Size.Y > 0)
-        {
-            io.DisplayFramebufferScale = _window.FramebufferSize / _window.Size;
-        }
+        io.DisplaySize = _window.FramebufferSize;
+        io.DisplayFramebufferScale = _window.FramebufferSize / _window.Size;
 
         io.DeltaTime = deltaSeconds;
     }
@@ -207,6 +203,7 @@ public unsafe class ImGuiController : DisposableObject
         ImGuizmo.SetImGuiContext(_imGuiContext);
 
         ImGui.StyleColorsDark();
+        ImGui.GetStyle().ScaleAllSizes(_window.DpiScale);
 
         ImGuiIOPtr io = ImGui.GetIO();
 

--- a/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiController.cs
+++ b/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiController.cs
@@ -233,6 +233,8 @@ public unsafe class ImGuiController : DisposableObject
 
         ImGuiIOPtr io = ImGui.GetIO();
 
+        io.Fonts.Clear();
+
         io.ConfigFlags |= ImGuiConfigFlags.NavEnableKeyboard;
         io.ConfigFlags |= ImGuiConfigFlags.DockingEnable;
         io.ConfigFlags |= ImGuiConfigFlags.ViewportsEnable;

--- a/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiFontConfig.cs
+++ b/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiFontConfig.cs
@@ -2,7 +2,7 @@
 
 namespace Graphics.Vulkan;
 
-public readonly record struct ImGuiFontConfig
+public record struct ImGuiFontConfig
 {
     public ImGuiFontConfig(string fontPath, int fontSize, Func<ImGuiIOPtr, nint>? getGlyphRange = null)
     {
@@ -13,9 +13,9 @@ public readonly record struct ImGuiFontConfig
         GetGlyphRange = getGlyphRange;
     }
 
-    public string FontPath { get; init; }
+    public string FontPath { get; set; }
 
-    public int FontSize { get; init; }
+    public int FontSize { get; set; }
 
-    public Func<ImGuiIOPtr, nint>? GetGlyphRange { get; init; }
+    public Func<ImGuiIOPtr, nint>? GetGlyphRange { get; set; }
 }

--- a/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiRenderer.cs
+++ b/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiRenderer.cs
@@ -247,6 +247,15 @@ float4 mainPS(VSOutput input) : SV_TARGET
         }
     }
 
+    public void RecreateFontDeviceTexture()
+    {
+        RemoveImGuiBinding(GetOrCreateImGuiBinding(_factory, _fontTexture));
+
+        _fontTexture.Dispose();
+
+        CreateFontDeviceTexture();
+    }
+
     protected override void Destroy()
     {
         _vertexBuffer.Dispose();
@@ -279,7 +288,7 @@ float4 mainPS(VSOutput input) : SV_TARGET
         return resourceSet;
     }
 
-    private void RecreateFontDeviceTexture()
+    private void CreateFontDeviceTexture()
     {
         ImGuiIOPtr io = ImGui.GetIO();
 
@@ -349,11 +358,11 @@ float4 mainPS(VSOutput input) : SV_TARGET
         _pipeline = _factory.CreateGraphicsPipeline(pipelineDescription);
         _pipeline.Name = "ImGui Pipeline";
 
-        RecreateFontDeviceTexture();
-
         foreach (Shader shader in shaders)
         {
             shader.Dispose();
         }
+
+        CreateFontDeviceTexture();
     }
 }

--- a/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiSizeConfig.cs
+++ b/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiSizeConfig.cs
@@ -5,57 +5,6 @@ namespace Graphics.Vulkan;
 
 public readonly record struct ImGuiSizeConfig
 {
-    public ImGuiSizeConfig(Vector2 windowPadding,
-                           float windowRounding,
-                           Vector2 windowMinSize,
-                           float childRounding,
-                           float popupRounding,
-                           Vector2 framePadding,
-                           float frameRounding,
-                           Vector2 itemSpacing,
-                           Vector2 itemInnerSpacing,
-                           Vector2 cellPadding,
-                           Vector2 touchExtraPadding,
-                           float indentSpacing,
-                           float columnsMinSpacing,
-                           float scrollbarSize,
-                           float scrollbarRounding,
-                           float grabMinSize,
-                           float grabRounding,
-                           float logSliderDeadzone,
-                           float tabRounding,
-                           float tabMinWidthForCloseButton,
-                           Vector2 separatorTextPadding,
-                           Vector2 displayWindowPadding,
-                           Vector2 displaySafeAreaPadding,
-                           float mouseCursorScale)
-    {
-        WindowPadding = windowPadding;
-        WindowRounding = windowRounding;
-        WindowMinSize = windowMinSize;
-        ChildRounding = childRounding;
-        PopupRounding = popupRounding;
-        FramePadding = framePadding;
-        FrameRounding = frameRounding;
-        ItemSpacing = itemSpacing;
-        ItemInnerSpacing = itemInnerSpacing;
-        CellPadding = cellPadding;
-        TouchExtraPadding = touchExtraPadding;
-        IndentSpacing = indentSpacing;
-        ColumnsMinSpacing = columnsMinSpacing;
-        ScrollbarSize = scrollbarSize;
-        ScrollbarRounding = scrollbarRounding;
-        GrabMinSize = grabMinSize;
-        GrabRounding = grabRounding;
-        LogSliderDeadzone = logSliderDeadzone;
-        TabRounding = tabRounding;
-        TabMinWidthForCloseButton = tabMinWidthForCloseButton;
-        SeparatorTextPadding = separatorTextPadding;
-        DisplayWindowPadding = displayWindowPadding;
-        DisplaySafeAreaPadding = displaySafeAreaPadding;
-        MouseCursorScale = mouseCursorScale;
-    }
-
     public Vector2 WindowPadding { get; init; }
 
     public float WindowRounding { get; init; }

--- a/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiSizeConfig.cs
+++ b/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiSizeConfig.cs
@@ -5,6 +5,34 @@ namespace Graphics.Vulkan;
 
 public record struct ImGuiSizeConfig
 {
+    public static ImGuiSizeConfig Default => new()
+    {
+        WindowPadding = new Vector2(8, 8),
+        WindowRounding = 0.0f,
+        WindowMinSize = new Vector2(32, 32),
+        ChildRounding = 0.0f,
+        PopupRounding = 0.0f,
+        FramePadding = new Vector2(4, 3),
+        FrameRounding = 0.0f,
+        ItemSpacing = new Vector2(8, 4),
+        ItemInnerSpacing = new Vector2(4, 4),
+        CellPadding = new Vector2(4, 2),
+        TouchExtraPadding = new Vector2(0, 0),
+        IndentSpacing = 21.0f,
+        ColumnsMinSpacing = 6.0f,
+        ScrollbarSize = 14.0f,
+        ScrollbarRounding = 9.0f,
+        GrabMinSize = 12.0f,
+        GrabRounding = 0.0f,
+        LogSliderDeadzone = 4.0f,
+        TabRounding = 4.0f,
+        TabMinWidthForCloseButton = 0.0f,
+        SeparatorTextPadding = new Vector2(20, 3),
+        DisplayWindowPadding = new Vector2(19, 19),
+        DisplaySafeAreaPadding = new Vector2(3, 3),
+        MouseCursorScale = 1.0f
+    };
+
     public Vector2 WindowPadding { get; set; }
 
     public float WindowRounding { get; set; }
@@ -53,35 +81,7 @@ public record struct ImGuiSizeConfig
 
     public float MouseCursorScale { get; set; }
 
-    public static ImGuiSizeConfig Default => new()
-    {
-        WindowPadding = new Vector2(8, 8),
-        WindowRounding = 0.0f,
-        WindowMinSize = new Vector2(32, 32),
-        ChildRounding = 0.0f,
-        PopupRounding = 0.0f,
-        FramePadding = new Vector2(4, 3),
-        FrameRounding = 0.0f,
-        ItemSpacing = new Vector2(8, 4),
-        ItemInnerSpacing = new Vector2(4, 4),
-        CellPadding = new Vector2(4, 2),
-        TouchExtraPadding = new Vector2(0, 0),
-        IndentSpacing = 21.0f,
-        ColumnsMinSpacing = 6.0f,
-        ScrollbarSize = 14.0f,
-        ScrollbarRounding = 9.0f,
-        GrabMinSize = 12.0f,
-        GrabRounding = 0.0f,
-        LogSliderDeadzone = 4.0f,
-        TabRounding = 4.0f,
-        TabMinWidthForCloseButton = 0.0f,
-        SeparatorTextPadding = new Vector2(20, 3),
-        DisplayWindowPadding = new Vector2(19, 19),
-        DisplaySafeAreaPadding = new Vector2(3, 3),
-        MouseCursorScale = 1.0f
-    };
-
-    public readonly ImGuiSizeConfig Scale(float scale)
+    public ImGuiSizeConfig Scale(float scale)
     {
         ImGuiSizeConfig imGuiSizeConfig = new()
         {

--- a/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiSizeConfig.cs
+++ b/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiSizeConfig.cs
@@ -1,0 +1,199 @@
+﻿using System.Numerics;
+using Hexa.NET.ImGui;
+
+namespace Graphics.Vulkan;
+
+public readonly record struct ImGuiSizeConfig
+{
+    public ImGuiSizeConfig(Vector2 windowPadding,
+                           float windowRounding,
+                           Vector2 windowMinSize,
+                           float childRounding,
+                           float popupRounding,
+                           Vector2 framePadding,
+                           float frameRounding,
+                           Vector2 itemSpacing,
+                           Vector2 itemInnerSpacing,
+                           Vector2 cellPadding,
+                           Vector2 touchExtraPadding,
+                           float indentSpacing,
+                           float columnsMinSpacing,
+                           float scrollbarSize,
+                           float scrollbarRounding,
+                           float grabMinSize,
+                           float grabRounding,
+                           float logSliderDeadzone,
+                           float tabRounding,
+                           float tabMinWidthForCloseButton,
+                           Vector2 separatorTextPadding,
+                           Vector2 displayWindowPadding,
+                           Vector2 displaySafeAreaPadding,
+                           float mouseCursorScale)
+    {
+        WindowPadding = windowPadding;
+        WindowRounding = windowRounding;
+        WindowMinSize = windowMinSize;
+        ChildRounding = childRounding;
+        PopupRounding = popupRounding;
+        FramePadding = framePadding;
+        FrameRounding = frameRounding;
+        ItemSpacing = itemSpacing;
+        ItemInnerSpacing = itemInnerSpacing;
+        CellPadding = cellPadding;
+        TouchExtraPadding = touchExtraPadding;
+        IndentSpacing = indentSpacing;
+        ColumnsMinSpacing = columnsMinSpacing;
+        ScrollbarSize = scrollbarSize;
+        ScrollbarRounding = scrollbarRounding;
+        GrabMinSize = grabMinSize;
+        GrabRounding = grabRounding;
+        LogSliderDeadzone = logSliderDeadzone;
+        TabRounding = tabRounding;
+        TabMinWidthForCloseButton = tabMinWidthForCloseButton;
+        SeparatorTextPadding = separatorTextPadding;
+        DisplayWindowPadding = displayWindowPadding;
+        DisplaySafeAreaPadding = displaySafeAreaPadding;
+        MouseCursorScale = mouseCursorScale;
+    }
+
+    public Vector2 WindowPadding { get; init; }
+
+    public float WindowRounding { get; init; }
+
+    public Vector2 WindowMinSize { get; init; }
+
+    public float ChildRounding { get; init; }
+
+    public float PopupRounding { get; init; }
+
+    public Vector2 FramePadding { get; init; }
+
+    public float FrameRounding { get; init; }
+
+    public Vector2 ItemSpacing { get; init; }
+
+    public Vector2 ItemInnerSpacing { get; init; }
+
+    public Vector2 CellPadding { get; init; }
+
+    public Vector2 TouchExtraPadding { get; init; }
+
+    public float IndentSpacing { get; init; }
+
+    public float ColumnsMinSpacing { get; init; }
+
+    public float ScrollbarSize { get; init; }
+
+    public float ScrollbarRounding { get; init; }
+
+    public float GrabMinSize { get; init; }
+
+    public float GrabRounding { get; init; }
+
+    public float LogSliderDeadzone { get; init; }
+
+    public float TabRounding { get; init; }
+
+    public float TabMinWidthForCloseButton { get; init; }
+
+    public Vector2 SeparatorTextPadding { get; init; }
+
+    public Vector2 DisplayWindowPadding { get; init; }
+
+    public Vector2 DisplaySafeAreaPadding { get; init; }
+
+    public float MouseCursorScale { get; init; }
+
+    public static ImGuiSizeConfig Default => new()
+    {
+        WindowPadding = new Vector2(8, 8),
+        WindowRounding = 0.0f,
+        WindowMinSize = new Vector2(32, 32),
+        ChildRounding = 0.0f,
+        PopupRounding = 0.0f,
+        FramePadding = new Vector2(4, 3),
+        FrameRounding = 0.0f,
+        ItemSpacing = new Vector2(8, 4),
+        ItemInnerSpacing = new Vector2(4, 4),
+        CellPadding = new Vector2(4, 2),
+        TouchExtraPadding = new Vector2(0, 0),
+        IndentSpacing = 21.0f,
+        ColumnsMinSpacing = 6.0f,
+        ScrollbarSize = 14.0f,
+        ScrollbarRounding = 9.0f,
+        GrabMinSize = 12.0f,
+        GrabRounding = 0.0f,
+        LogSliderDeadzone = 4.0f,
+        TabRounding = 4.0f,
+        TabMinWidthForCloseButton = 0.0f,
+        SeparatorTextPadding = new Vector2(20, 3),
+        DisplayWindowPadding = new Vector2(19, 19),
+        DisplaySafeAreaPadding = new Vector2(3, 3),
+        MouseCursorScale = 1.0f
+    };
+
+    public readonly ImGuiSizeConfig Scale(float scale)
+    {
+        ImGuiSizeConfig imGuiSizeConfig = new()
+        {
+            WindowPadding = ScaleVector2(WindowPadding, scale),
+            WindowRounding = ScaleFloat(WindowRounding, scale),
+            WindowMinSize = ScaleVector2(WindowMinSize, scale),
+            ChildRounding = ScaleFloat(ChildRounding, scale),
+            PopupRounding = ScaleFloat(PopupRounding, scale),
+            FramePadding = ScaleVector2(FramePadding, scale),
+            FrameRounding = ScaleFloat(FrameRounding, scale),
+            ItemSpacing = ScaleVector2(ItemSpacing, scale),
+            ItemInnerSpacing = ScaleVector2(ItemInnerSpacing, scale),
+            CellPadding = ScaleVector2(CellPadding, scale),
+            TouchExtraPadding = ScaleVector2(TouchExtraPadding, scale),
+            IndentSpacing = ScaleFloat(IndentSpacing, scale),
+            ColumnsMinSpacing = ScaleFloat(ColumnsMinSpacing, scale),
+            ScrollbarSize = ScaleFloat(ScrollbarSize, scale),
+            ScrollbarRounding = ScaleFloat(ScrollbarRounding, scale),
+            GrabMinSize = ScaleFloat(GrabMinSize, scale),
+            GrabRounding = ScaleFloat(GrabRounding, scale),
+            LogSliderDeadzone = ScaleFloat(LogSliderDeadzone, scale),
+            TabRounding = ScaleFloat(TabRounding, scale),
+            TabMinWidthForCloseButton = ScaleFloat(TabMinWidthForCloseButton, scale),
+            SeparatorTextPadding = ScaleVector2(SeparatorTextPadding, scale),
+            DisplayWindowPadding = ScaleVector2(DisplayWindowPadding, scale),
+            DisplaySafeAreaPadding = ScaleVector2(DisplaySafeAreaPadding, scale),
+            MouseCursorScale = ScaleFloat(MouseCursorScale, scale)
+        };
+
+        return imGuiSizeConfig;
+    }
+
+    public readonly void Apply(ImGuiStylePtr style)
+    {
+        style.WindowPadding = WindowPadding;
+        style.WindowRounding = WindowRounding;
+        style.WindowMinSize = WindowMinSize;
+        style.ChildRounding = ChildRounding;
+        style.PopupRounding = PopupRounding;
+        style.FramePadding = FramePadding;
+        style.FrameRounding = FrameRounding;
+        style.ItemSpacing = ItemSpacing;
+        style.ItemInnerSpacing = ItemInnerSpacing;
+        style.CellPadding = CellPadding;
+        style.TouchExtraPadding = TouchExtraPadding;
+        style.IndentSpacing = IndentSpacing;
+        style.ColumnsMinSpacing = ColumnsMinSpacing;
+        style.ScrollbarSize = ScrollbarSize;
+        style.ScrollbarRounding = ScrollbarRounding;
+        style.GrabMinSize = GrabMinSize;
+        style.GrabRounding = GrabRounding;
+        style.LogSliderDeadzone = LogSliderDeadzone;
+        style.TabRounding = TabRounding;
+        style.TabMinWidthForCloseButton = TabMinWidthForCloseButton;
+        style.SeparatorTextPadding = SeparatorTextPadding;
+        style.DisplayWindowPadding = DisplayWindowPadding;
+        style.DisplaySafeAreaPadding = DisplaySafeAreaPadding;
+        style.MouseCursorScale = MouseCursorScale;
+    }
+
+    private static float ScaleFloat(float value, float scale) => Convert.ToInt32(value * scale);
+
+    private static Vector2 ScaleVector2(Vector2 value, float scale) => new(Convert.ToInt32(value.X * scale), Convert.ToInt32(value.Y * scale));
+}

--- a/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiSizeConfig.cs
+++ b/Source/Graphics/Graphics.Vulkan/ImGui/ImGuiSizeConfig.cs
@@ -3,55 +3,55 @@ using Hexa.NET.ImGui;
 
 namespace Graphics.Vulkan;
 
-public readonly record struct ImGuiSizeConfig
+public record struct ImGuiSizeConfig
 {
-    public Vector2 WindowPadding { get; init; }
+    public Vector2 WindowPadding { get; set; }
 
-    public float WindowRounding { get; init; }
+    public float WindowRounding { get; set; }
 
-    public Vector2 WindowMinSize { get; init; }
+    public Vector2 WindowMinSize { get; set; }
 
-    public float ChildRounding { get; init; }
+    public float ChildRounding { get; set; }
 
-    public float PopupRounding { get; init; }
+    public float PopupRounding { get; set; }
 
-    public Vector2 FramePadding { get; init; }
+    public Vector2 FramePadding { get; set; }
 
-    public float FrameRounding { get; init; }
+    public float FrameRounding { get; set; }
 
-    public Vector2 ItemSpacing { get; init; }
+    public Vector2 ItemSpacing { get; set; }
 
-    public Vector2 ItemInnerSpacing { get; init; }
+    public Vector2 ItemInnerSpacing { get; set; }
 
-    public Vector2 CellPadding { get; init; }
+    public Vector2 CellPadding { get; set; }
 
-    public Vector2 TouchExtraPadding { get; init; }
+    public Vector2 TouchExtraPadding { get; set; }
 
-    public float IndentSpacing { get; init; }
+    public float IndentSpacing { get; set; }
 
-    public float ColumnsMinSpacing { get; init; }
+    public float ColumnsMinSpacing { get; set; }
 
-    public float ScrollbarSize { get; init; }
+    public float ScrollbarSize { get; set; }
 
-    public float ScrollbarRounding { get; init; }
+    public float ScrollbarRounding { get; set; }
 
-    public float GrabMinSize { get; init; }
+    public float GrabMinSize { get; set; }
 
-    public float GrabRounding { get; init; }
+    public float GrabRounding { get; set; }
 
-    public float LogSliderDeadzone { get; init; }
+    public float LogSliderDeadzone { get; set; }
 
-    public float TabRounding { get; init; }
+    public float TabRounding { get; set; }
 
-    public float TabMinWidthForCloseButton { get; init; }
+    public float TabMinWidthForCloseButton { get; set; }
 
-    public Vector2 SeparatorTextPadding { get; init; }
+    public Vector2 SeparatorTextPadding { get; set; }
 
-    public Vector2 DisplayWindowPadding { get; init; }
+    public Vector2 DisplayWindowPadding { get; set; }
 
-    public Vector2 DisplaySafeAreaPadding { get; init; }
+    public Vector2 DisplaySafeAreaPadding { get; set; }
 
-    public float MouseCursorScale { get; init; }
+    public float MouseCursorScale { get; set; }
 
     public static ImGuiSizeConfig Default => new()
     {

--- a/Source/Renderer/MainWindow.cs
+++ b/Source/Renderer/MainWindow.cs
@@ -21,7 +21,7 @@ internal sealed unsafe class MainWindow : DisposableObject
         _graphicsDevice = App.Context.CreateGraphicsDevice(App.Context.EnumeratePhysicalDevices().First(), _window);
         _imGuiController = new ImGuiController(_window,
                                                _graphicsDevice,
-                                               new ImGuiFontConfig("Assets/Fonts/MSYH.TTC", Convert.ToInt32(14.0f * _window.DpiScale), (a) => (nint)a.Fonts.GetGlyphRangesChineseFull()));
+                                               new ImGuiFontConfig("Assets/Fonts/MSYH.TTC", 14, (a) => (nint)a.Fonts.GetGlyphRangesChineseFull()));
         _commandList = _graphicsDevice.ResourceFactory.CreateGraphicsCommandList();
         _controls = [];
         _scenes = [];

--- a/Source/Renderer/MainWindow.cs
+++ b/Source/Renderer/MainWindow.cs
@@ -21,7 +21,7 @@ internal sealed unsafe class MainWindow : DisposableObject
         _graphicsDevice = App.Context.CreateGraphicsDevice(App.Context.EnumeratePhysicalDevices().First(), _window);
         _imGuiController = new ImGuiController(_window,
                                                _graphicsDevice,
-                                               new ImGuiFontConfig("Assets/Fonts/MSYH.TTC", 14, (a) => (nint)a.Fonts.GetGlyphRangesChineseFull()));
+                                               new ImGuiFontConfig("Assets/Fonts/MSYH.TTC", Convert.ToInt32(14.0f * _window.DpiScale), (a) => (nint)a.Fonts.GetGlyphRangesChineseFull()));
         _commandList = _graphicsDevice.ResourceFactory.CreateGraphicsCommandList();
         _controls = [];
         _scenes = [];

--- a/Source/Renderer/MainWindow.cs
+++ b/Source/Renderer/MainWindow.cs
@@ -1,5 +1,6 @@
 ﻿using Graphics.Core;
 using Graphics.Vulkan;
+using Hexa.NET.ImGui;
 using Renderer.Components;
 using Renderer.Controls;
 using Renderer.Scenes;
@@ -97,6 +98,8 @@ internal sealed unsafe class MainWindow : DisposableObject
     private void Window_Render(object? sender, RenderEventArgs e)
     {
         _imGuiController.Update(e.DeltaTime);
+
+        ImGui.ShowDemoWindow();
 
         foreach (Control control in _controls)
         {

--- a/Source/Renderer/Renderer.csproj
+++ b/Source/Renderer/Renderer.csproj
@@ -13,6 +13,10 @@
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 	</ItemGroup>

--- a/Source/Renderer/app.manifest
+++ b/Source/Renderer/app.manifest
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+	<asmv3:application>
+		<asmv3:windowsSettings>
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+		</asmv3:windowsSettings>
+	</asmv3:application>
+</assembly>


### PR DESCRIPTION
#### PR Classification
新功能和改进

#### PR Summary
此 PR 主要更新了包版本并添加了与 DPI 缩放和 ImGui 相关的新功能。
- `Graphics.Core.csproj`：将 `Hexa.NET.ImGui` 和 `Hexa.NET.ImGuizmo` 包从 `1.0.4` 升级到 `1.1.0`
- `Window.Status.cs` 和 `Window.cs`：添加了 `DpiScale` 属性和 `IsMouseFocusOnWindow`、`SetTextIputRect` 方法
- `ImGuiController.cs`：添加了多个字段和方法以支持 DPI 缩放和视口变化处理
- `ImGuiFontConfig.cs` 和 `ImGuiRenderer.cs`：更新了 `ImGuiFontConfig` 结构体和字体设备纹理相关方法
- `app.manifest`：添加了应用程序的 DPI 感知设置文件
